### PR TITLE
Allow more vertex names

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,16 @@ specified below.
 ### Vertices
 
 A vertex is specified simply by a name that identifies that vertex. Vertex
-names may contain letters, digits and underscores (`_`). Multiple vertices can
-be defined on a single line using the following syntax (spaces are optional):
+names may contain any character that is not a
+[control character](https://en.wikipedia.org/wiki/Control_character) or used as
+part of Kale syntax. Multiple vertices can be defined on a single line using the
+following syntax (spaces are optional):
 
 ```kale
-vertex1, vertex2, vertex3
+vertex 1, vertex 2, vertex 3
 ```
 
-If a vertex is defined more than once the later occurences are ignored.
+If a vertex is defined more than once the later definitions are silently ignored.
 
 > [!TIP]  
 > Any vertex that starts with an underscore (`_`) will be treated as an

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -22,18 +22,20 @@ export const DEFAULT_FLAGS: Flags = {
 export const COMMENT_PATTERN = /\/\/.+/
 export const FLAG_PREFIX = "-"
 
+export const VERTEX_NAME_PATTERN = String.raw`[^\x00-\x1F\s,()$\\-]+(?:\s+[^\x00-\x1F\s,()$\\-]+)*`
 export const EDGE_VALIDATE_PATTERN =
-    /^(\(\s*(\w+?\s*[,]\s*\w+?)\s*\)(\s*[,]\s*)?)+$/
-export const EDGE_SEARCH_PATTERN = /\(\s*(\w+?)\s*[,]\s*(\w+?)\s*\)/g
+    RegExp(String.raw`^(\(\s*(${VERTEX_NAME_PATTERN}\s*[,]\s*${VERTEX_NAME_PATTERN})\s*\)(\s*[,]\s*)?)+$`)
+export const EDGE_SEARCH_PATTERN = RegExp(String.raw`\(\s*(${VERTEX_NAME_PATTERN})\s*[,]\s*(${VERTEX_NAME_PATTERN})\s*\)`, 'g')
 
 export const ADJACENCY_MATRIX_VALIDATE_PATTERN = /^[\s\d]+$/
 export const ADJACENCY_MATRIX_SEARCH_PATTERN = /\d+/g
 
-export const PATH_VALIDATE_PATTERN = /^(\w+\s*-\s*)*\w+\s*$/
-export const PATH_SEARCH_PATTERN = /\w+(?=\s*(-|$))/g
+export const PATH_VALIDATE_PATTERN = RegExp(String.raw`^(${VERTEX_NAME_PATTERN}\s*-\s*)*${VERTEX_NAME_PATTERN}\s*$`)
+export const PATH_SEARCH_PATTERN = RegExp(String.raw`${VERTEX_NAME_PATTERN}(?=\s*(-|$))`, 'g')
 
-export const VERTEX_VALIDATE_PATTERN = /^(\w+\s*,\s*)*\w+\s*,?$/
-export const VERTEX_SEARCH_PATTERN = /\w+(?=\s*(,|$))/g
+export const VERTEX_VALIDATE_PATTERN = RegExp(String.raw`^(${VERTEX_NAME_PATTERN}\s*,\s*)*${VERTEX_NAME_PATTERN}\s*,?$`)
+export const VERTEX_SEARCH_PATTERN = RegExp(String.raw`${VERTEX_NAME_PATTERN}(?=\s*(,|$))`, 'g')
+
 
 export const INVISIBLE_VERTEX_PREFIX = "_"
 


### PR DESCRIPTION
This PR closes #14 

It extends vertex names to allow them to consist of any characters that are not control characters or used as part of Kale syntax